### PR TITLE
Add IP and port allocated to the client in the response header of the CONNECT UDP listen request (Closes #12)

### DIFF
--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -176,13 +176,7 @@ bind to this request. From then and until the tunnel is closed, the proxy
 SHALL send packets received on these IP-port tuples to the client. The proxy
 MUST communicate the selected addresses and ports to the client using
 the "Proxy-Public-Address" header. The format of that header is defined below
-using IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
-
-The proxy MUST then respond with the allocated IP and port pairings using the
-Proxy-Public-Address response header which is defined as a List of Strings.
-The list contains a maximum of one IPv4 address and port, and one IPv6 address
-and port each. IP-literal, IPv4address and port are defined in
-{{Section 3 of !URI=RFC3986}}
+using IP-literal, IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
 
 ~~~ ascii-art
 proxy-public-address = List of IP:Port pairings

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -186,8 +186,12 @@ IP-port-pairing = ( IPv4address / "[" IPv6address "]" ) ":" port
 ~~~
 {: #target-format title="Proxy Address Format"}
 
-The proxy MUST use one each of IPv4address and IPv6address when
-proxy-public-address is defined as two IP-port-pairings.
+If the proxy sends two IP-port pairings, they MUST be of different
+address families. If the client receives a Proxy-Public-Address field
+with two IP-port pairings of the same address family, it MUST treat
+the response as malformed. Similarly, if the field is missing or
+contains a number of pairings different from one or two, it MUST
+treat the response as malformed.
 Note that since the addresses are conveyed in HTTP response headers,
 a subsequent change of addresses on the proxy cannot be conveyed to the client.
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -168,9 +168,17 @@ parameters. Receivers MUST ignore unknown parameters.
 
 
 # The proxy-public-address Response Header Field {#response}
-Upon accepting the request, the "proxy-public-address" response header,
-MUST contain the IP and the UDP port which are allocated to the client by the
-proxy in the format {IP-Address}:{UDP-Port}
+
+Upon accepting the request, the proxy MUST allocate either one or both of IPv4address to port and IPv6address to port pairings. IPv4address, IPv6address and port are defined in {{!URI=RFC3986}}
+
+The proxy must then respond with the allocated IP and port pairings using the "proxy-public-address" response header defined as follows:
+
+~~~ ascii-art
+proxy-public-address = IP-port-pairing (, IP-port-pairing)
+IP-port-pairing = IPv4address:port / IPv6address:port
+~~~
+{: #target-format title="Proxy Address Format"}
+
 
 # Proxy behavior
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -170,7 +170,8 @@ parameters. Receivers MUST ignore unknown parameters.
 # The Proxy-Public-Address Response Header Field {#response}
 
 Upon accepting the request, the proxy MUST select at least one public IP
-address to bind. For each selected address, it MUST select an open port to
+address to bind. The proxy MAY also select a second address from a different address
+family. For each selected address, it MUST select an open port to
 bind to this request. From then and until the tunnel is closed, the proxy
 SHALL send packets received on these IP-port tuples to the client. The proxy
 then MUST communicate the selected addresses and ports to the client using

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -167,11 +167,18 @@ for the connect-udp-listen header field value, but future documents might define
 parameters. Receivers MUST ignore unknown parameters.
 
 
-# The proxy-public-address Response Header Field {#response}
+# The Proxy-Public-Address Response Header Field {#response}
 
-Upon accepting the request, the proxy MUST select at least one public IP address to bind. For each selected address, it MUST select an open port to bind to this request. From then and until the tunnel is closed, the proxy SHALL send packets received on these IP-port tuples to the client. The proxy then MUST communicate the selected addresses and ports to the client using the "Proxy-Public-Address" header. The format of that header is defined below using IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
+Upon accepting the request, the proxy MUST select at least one public IP
+address to bind. For each selected address, it MUST select an open port to
+bind to this request. From then and until the tunnel is closed, the proxy
+SHALL send packets received on these IP-port tuples to the client. The proxy
+then MUST communicate the selected addresses and ports to the client using
+the "Proxy-Public-Address" header. The format of that header is defined below
+using IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
 
-The proxy must then respond with the allocated IP and port pairings using the "proxy-public-address" response header defined as follows:
+The proxy MUST then respond with the allocated IP and port pairings using the
+Proxy-Public-Address response header defined as follows:
 
 ~~~ ascii-art
 proxy-public-address = IP-port-pairing (, IP-port-pairing)
@@ -179,6 +186,7 @@ IP-port-pairing = IPv4address:port / IPv6address:port
 ~~~
 {: #target-format title="Proxy Address Format"}
 
+Once assigned, the allocated IP and ports cannot be updated mid-stream.
 
 # Proxy behavior
 
@@ -262,7 +270,8 @@ back to the client.
             <--------  STREAM(44): HEADERS
                          :status = 200
                          capsule-protocol = ?1
-                         proxy-public-address = 192.0.2.45:54321,[2001:db8::1234]:54321
+                         proxy-public-address = 192.0.2.45:54321,
+                         		   [2001:db8::1234]:54321
 
 /* Wait for STUN server to respond to UDP packet. */
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -174,7 +174,7 @@ address to bind. The proxy MAY also select a second address from a different add
 family. For each selected address, it MUST select an open port to
 bind to this request. From then and until the tunnel is closed, the proxy
 SHALL send packets received on these IP-port tuples to the client. The proxy
-then MUST communicate the selected addresses and ports to the client using
+MUST communicate the selected addresses and ports to the client using
 the "Proxy-Public-Address" header. The format of that header is defined below
 using IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -186,6 +186,8 @@ IP-port-pairing = ( IPv4address / "[" IPv6address "]" ) ":" port
 ~~~
 {: #target-format title="Proxy Address Format"}
 
+The proxy MUST use one each of IPv4address and IPv6address when
+proxy-public-address is defined as two IP-port-pairings.
 Note that since the addresses are conveyed in HTTP response headers,
 a subsequent change of addresses on the proxy cannot be conveyed to the client.
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -172,26 +172,26 @@ parameters. Receivers MUST ignore unknown parameters.
 # The Proxy-Public-Address Response Header Field {#response}
 
 Upon accepting the request, the proxy MUST select at least one public IP
-address to bind. The proxy MAY also select a second address from a different address
-family. For each selected address, it MUST select an open port to
-bind to this request. From then and until the tunnel is closed, the proxy
-SHALL send packets received on these IP-port tuples to the client. The proxy
-MUST communicate the selected addresses and ports to the client using
-the "Proxy-Public-Address" header. The format of that header is defined below
-using IP-literal, IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
+address to bind. The proxy MAY assign more addresses. For each selected
+address, it MUST select an open port to bind to this request. From then
+and until the tunnel is closed, the proxy SHALL send packets received on
+these IP-port tuples to the client. The proxy MUST communicate the selected
+addresses and ports to the client using the "Proxy-Public-Address" header.
+The header is defined as a List of IP-Port-tuples.
+The format of the tuple is defined using IP-literal, IPv4address, IPv6address
+and port from {{Section 3.2 of !URI=RFC3986}}.
 
 ~~~ ascii-art
-proxy-public-address = ip-port-tuple *( "," ip-port-tuple )
 ip-port-tuple = ( IP-literal / IPv4address ) ":" port
 ~~~
 {: #target-format title="Proxy Address Format"}
 
-If the proxy sends two IP-port pairings, they MUST be of different
-address families. If the client receives a Proxy-Public-Address field
-with two IP-port pairings of the same address family, it MUST treat
-the response as malformed. Similarly, if the field is missing or
-contains a number of pairings different from one or two, it MUST
-treat the response as malformed.
+
+When a single IP-Port tuple is provided in the Proxy-Public-Address field, the
+proxy MUST use the same public IP and Port for the remainder of the connection.
+When multiple tuples are provided, maintaining address stability per address
+family is RECOMMENDED.
+
 Note that since the addresses are conveyed in HTTP response headers,
 a subsequent change of addresses on the proxy cannot be conveyed to the client.
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -262,7 +262,7 @@ back to the client.
             <--------  STREAM(44): HEADERS
                          :status = 200
                          capsule-protocol = ?1
-                         proxy-public-address = 192.10.11.45:3030
+                         proxy-public-address = 192.0.2.45:54321,[2001:db8::1234]:54321
 
 /* Wait for STUN server to respond to UDP packet. */
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -186,7 +186,8 @@ IP-port-pairing = IPv4address:port / IPv6address:port
 ~~~
 {: #target-format title="Proxy Address Format"}
 
-Once assigned, the allocated IP and ports cannot be updated mid-stream.
+Note that since the addresses are conveyed in HTTP response headers,
+a subsequent change of addresses on the proxy cannot be conveyed to the client.
 
 # Proxy behavior
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -182,7 +182,7 @@ Proxy-Public-Address response header defined as follows:
 
 ~~~ ascii-art
 proxy-public-address = IP-port-pairing (, IP-port-pairing)
-IP-port-pairing = IPv4address:port / IPv6address:port
+IP-port-pairing = ( IPv4address / "[" IPv6address "]" ) ":" port
 ~~~
 {: #target-format title="Proxy Address Format"}
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -179,8 +179,8 @@ the "Proxy-Public-Address" header. The format of that header is defined below
 using IP-literal, IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
 
 ~~~ ascii-art
-proxy-public-address = List of IP:Port pairings
-IP:Port pairing = IP-literal:Port / IPv4address:Port
+proxy-public-address = ip-port-tuple *( "," ip-port-tuple )
+ip-port-tuple = ( IP-literal / IPv4address ) ":" port
 ~~~
 {: #target-format title="Proxy Address Format"}
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -110,7 +110,9 @@ target_port variables to the '*' character (ASCII character 0x2A).
 Before sending its UDP Proxying request to the proxy, the client allocates an
 even-numbered context ID, see {{Section 4 of CONNECT-UDP}}. The client then adds
 the "connect-udp-listen" header field to its UDP Proxying request, with its
-value set as the allocated context ID, see {{hdr}}.
+value set as the allocated context ID, see {{hdr}}. If the proxy accepts the
+CONNECT UDP Listener request, it adds the allocated public IP and target for the
+client to the response, see {{response}}.
 
 # HTTP Datagram Payload Format {#format}
 
@@ -163,6 +165,12 @@ value type MUST be handled as if the field were not present by the recipients
 and therefore is to be ignored). This document does not define any parameters
 for the connect-udp-listen header field value, but future documents might define
 parameters. Receivers MUST ignore unknown parameters.
+
+
+# The proxy-public-address Response Header Field {#response}
+Upon accepting the request, the "proxy-public-address" response header,
+MUST contain the IP and the UDP port which are allocated to the client by the
+proxy in the format {IP-Address}:{UDP-Port}
 
 # Proxy behavior
 
@@ -246,6 +254,7 @@ back to the client.
             <--------  STREAM(44): HEADERS
                          :status = 200
                          capsule-protocol = ?1
+                         proxy-public-address = 192.10.11.45:3030
 
 /* Wait for STUN server to respond to UDP packet. */
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -280,7 +280,7 @@ back to the client.
             <--------  STREAM(44): HEADERS
                          :status = 200
                          capsule-protocol = ?1
-                         proxy-public-address = 192.0.2.45:54321,
+                         proxy-public-address = 192.0.2.45:54321,  \
                          		   [2001:db8::1234]:54321
 
 /* Wait for STUN server to respond to UDP packet. */

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -179,11 +179,14 @@ the "Proxy-Public-Address" header. The format of that header is defined below
 using IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
 
 The proxy MUST then respond with the allocated IP and port pairings using the
-Proxy-Public-Address response header defined as follows:
+Proxy-Public-Address response header which is defined as a List of Strings.
+The list contains a maximum of one IPv4 address and port, and one IPv6 address
+and port each. IP-literal, IPv4address and Port are defined in
+{{Section 3 of !URI=RFC3986}}
 
 ~~~ ascii-art
-proxy-public-address = IP-port-pairing (, IP-port-pairing)
-IP-port-pairing = ( IPv4address / "[" IPv6address "]" ) ":" port
+proxy-public-address = List of IP:Port pairings
+IP:Port pairing = IP-literal:Port / IPv4address:Port
 ~~~
 {: #target-format title="Proxy Address Format"}
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -95,7 +95,9 @@ Proxying HTTP request.
 
 This document uses terminology from {{CONNECT-UDP}} and notational conventions
 from {{!QUIC=RFC9000}}. This document uses the terms Integer and List from
-{{Section 3 of !STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing. This document uses Augmented Backus-Naur Form and parsing/serialization behvaviors from {{!ABNF=RFC5234}}
+{{Section 3 of !STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing.
+This document uses Augmented Backus-Naur Form and parsing/serialization
+behaviors from {{!ABNF=RFC5234}}
 
 
 # Proxied UDP Binding Mechanism {#mechanism}

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -95,7 +95,7 @@ Proxying HTTP request.
 
 This document uses terminology from {{CONNECT-UDP}} and notational conventions
 from {{!QUIC=RFC9000}}. This document uses the terms Integer and List from
-{{Section 3 of !STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing.
+{{Section 3 of !STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing. This document uses Augmented Backus-Naur Form and parsing/serialization behvaviors from {{!ABNF=RFC5234}}
 
 
 # Proxied UDP Binding Mechanism {#mechanism}

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -169,7 +169,7 @@ parameters. Receivers MUST ignore unknown parameters.
 
 # The proxy-public-address Response Header Field {#response}
 
-Upon accepting the request, the proxy MUST allocate either one or both of IPv4address to port and IPv6address to port pairings. IPv4address, IPv6address and port are defined in {{!URI=RFC3986}}
+Upon accepting the request, the proxy MUST select at least one public IP address to bind. For each selected address, it MUST select an open port to bind to this request. From then and until the tunnel is closed, the proxy SHALL send packets received on these IP-port tuples to the client. The proxy then MUST communicate the selected addresses and ports to the client using the "Proxy-Public-Address" header. The format of that header is defined below using IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
 
 The proxy must then respond with the allocated IP and port pairings using the "proxy-public-address" response header defined as follows:
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -181,7 +181,7 @@ using IPv4address, IPv6address and port from {{Section 3.2 of !URI=RFC3986}}.
 The proxy MUST then respond with the allocated IP and port pairings using the
 Proxy-Public-Address response header which is defined as a List of Strings.
 The list contains a maximum of one IPv4 address and port, and one IPv6 address
-and port each. IP-literal, IPv4address and Port are defined in
+and port each. IP-literal, IPv4address and port are defined in
 {{Section 3 of !URI=RFC3986}}
 
 ~~~ ascii-art


### PR DESCRIPTION
Closes #12