### PR TITLE
Compress away IP and Port using Context IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This is the working area for the MASQUE WG Internet-Draft, "Proxying Listener UD
 
 * [Editor's Copy](https://ietf-wg-masque.github.io/draft-ietf-masque-connect-udp-listen/draft-ietf-masque-connect-udp-listen.html)
 * [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-masque-connect-udp-listen)
-* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ietf-masque-connect-udp-listen)
-* [Compare Editor's Copy to Individual Draft](https://ietf-wg-masque.github.io/draft-ietf-masque-connect-udp-listen/#go.draft-ietf-masque-connect-udp-listen.diff)
+* [Working Group Draft](https://datatracker.ietf.org/doc/html/draft-ietf-masque-connect-udp-listen)
+* [Compare Editor's Copy to Working Group Draft](https://ietf-wg-masque.github.io/draft-ietf-masque-connect-udp-listen/#go.draft-ietf-masque-connect-udp-listen.diff)
 
 
 ## Contributing

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -280,7 +280,7 @@ to 0 when allocating an uncompressed Context ID, as defined in {{contextid}}.
 The Compression Close capsule serves the following purposes. As a response to
 reject a COMPRESSION_ASSIGN request and to close or clean up any existing
 compression mappings. Once a COMPRESSION_CLOSE has been exchanged between
-endpoints, they MUST NOT use that Context ID until it is re-assigned via a 
+endpoints, they MUST NOT use that Context ID until it is re-assigned via a
 COMPRESSION_ASSIGN exchange.
 
 ~~~

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -136,7 +136,7 @@ context ID is set to one previously registered for compressed payloads.
 (See {{contextid}} for compressed and uncompressed assignments.)
 
 ~~~ ascii-art
-Bound UDP Uncompressed Payload {
+Uncompressed Bound UDP Proxying Payload {
   IP Version (8),
   IP Address (32..128),
   UDP Port (16),

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -172,7 +172,7 @@ non zero Context IDs as defined under {{compression}}.
 Receiving and forwarding from Context ID 0 is enabled by default, but may be
 disabled; see {{restrictingips}}.
 
-## Header Compression {#compression}
+## Address Compression {#compression}
 
 The client MAY choose to map IP and port information per datagram against the
 Context ID defined in {{contextid}}. In such a case, the client MUST send a

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -101,8 +101,8 @@ from {{!QUIC=RFC9000}}. This document uses the terms Integer and List from
 
 In unextended UDP Proxying requests, the target host is encoded in the HTTP
 request path or query. For Listener UDP Proxying, it is either conveyed in each
-HTTP Datagram, see {{format}} or registered via capsules and then compressed,
-see {{contextid}}.
+HTTP Datagram (see {{format}}), or registered via capsules and then compressed
+(see {{contextid}}).
 
 When performing URI Template Expansion of the UDP Proxying template (see
 {{Section 3 of CONNECT-UDP}}), the client sets both the target_host and the

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -182,12 +182,13 @@ context ID set to 0.
 
 An even context ID MUST be used by clients to allocate uncompressed or compressed
 contexts, and an odd context ID MUST be used by the proxy to allocate compressed
-context IDs. A Client and a proxy MUST exhange COMPRESSION_ASSIGN packets for a
-given context ID to guarantee that all payloads are received and processed by the
-other party, see {{compression}}. They MAY pre-emptively use Context IDs not
-acknowledged by the other party yet, knowing that those packets MAY be lost sinc
-the COMPRESSION_ASSIGN request receiving proxy or client is not guaranteed to be
-ready to accept payloads until a COMPRESSION_ASSIGN response is echoed back.
+context IDs. A Client and a proxy MUST exhange a COMPRESSION_ASSIGN request and echo
+response in order to successfully allocate a new context ID and guarantee that all
+payloads are received and processed by the other party, see {{compression}}. They
+MAY pre-emptively use Context IDs not yet acknowledged by the other party, knowing
+that those packets MAY be lost since the COMPRESSION_ASSIGN request receiving proxy
+or client is not guaranteed to be ready to accept payloads until a COMPRESSION_ASSIGN
+response is echoed back.
 
 ## Address Compression {#compression}
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -181,7 +181,7 @@ context ID set to 0.
 
 As mandated in {{Section 4 of CONNECT-UDP}}, clients will allocate even context IDs
 while proxies will allocate odd ones.
-They MAY pre-emptively use Context IDs not yet acknowledged by the other party, knowing that those packets MAY be lost since the COMPRESSION_ASSIGN request receiving proxy
+They MAY pre-emptively use Context IDs not yet acknowledged by the other party, knowing that those packets can be lost since the COMPRESSION_ASSIGN request receiving proxy
 or client is not guaranteed to be ready to accept payloads until a COMPRESSION_ASSIGN
 response is echoed back.
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -111,7 +111,7 @@ When performing URI Template Expansion of the UDP Proxying template (see
 target_port variables to the '*' character (ASCII character 0x2A).
 
 When sending the UDP Proxying request to the proxy, the client adds
-the "Connect-UDP-Bind" header field to identify it as such. 
+the "Connect-UDP-Bind" header field to identify it as such.
 If the proxy accepts the CONNECT UDP Bind request, it adds the allocated public
 IP:port tuples for the client to the response, see {{response}}.
 Both client and proxy can then negotiate even and odd numbered context IDs to

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -122,7 +122,7 @@ are configured as defined in {{compression}}.
 When HTTP Datagrams {{!HTTP-DGRAM=RFC9297}} associated with this Bound UDP
 Proxying request contain the Connect-UDP-Bind header field,
 the format of their UDP Proxying Payload field (see {{Section 5 of
-CONNECT-UDP}}) is defined by {{dgram-format}} when context ID is set to be used
+CONNECT-UDP}}) is defined by {{dgram-format}} when context ID is set to be
 used for uncompressed connect-udp bind and {{dgram-format-compressed}} when
 context ID is set to one previously registered for compressed payloads.
 (See {{contextid}} for compressed and uncompressed assignments.)

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -247,6 +247,7 @@ Capsule {
 ~~~ ascii-art
 Capsule {
   Type COMPRESSION_CLOSE (0x07),
+  Length (i),
   Context ID (i),
 }
 ~~~

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -174,8 +174,10 @@ octets" in {{UDP}}).
 
 # Context ID {#contextid}
 
-Context ID values MUST always be greater than 0. A payload with value 0 MUST
-be dropped by the receiving party.
+The context ID 0 was reserved by unextended connect-udp and is not used by this extension.
+Once an endpoint has ascertained that the peer supports this extension, the endpoint MUST NOT
+send any datagrams with context ID set to 0, and MUST drop any received datagrams with
+context ID set to 0.
 
 An even context ID MUST be used by clients to send packets to the proxy, and an odd
 context ID MUST be used by the proxy to send packets to the client. A Client and

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -263,7 +263,7 @@ to 0 when allocating an uncompressed Context ID, as defined in {{contextid}}.
 
 The Compression Close capsule serves the following purposes. As a response to reject a COMPRESSION_ASSIGN request and to close or clean up any existing compression mappings. Once a COMPRESSION_CLOSE is sent for a given Context ID, the sending party MAY drop any datagrams received for that Context ID until it is reallocated through a COMPRESSION_ASSIGN exchange.
 
-~~~ ascii-art
+~~~
 Capsule {
   Type COMPRESSION_CLOSE (0x39B9914F),
   Length (i),

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -249,8 +249,8 @@ Capsule {
 Target Information {
   Context ID (i),
   IP Version (8),
-  IP Address (32..128),
-  UDP Port (16),
+  [IP Address (32..128)],
+  [UDP Port (16)],
 }
 ~~~
 {: #targetmappingformat title="Target Information Format"}

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -228,7 +228,7 @@ context ID to address and port. Second, the receiver MUST echo an identical COMP
 if it rejects the mapping, the receiver MUST respond by sending a
 COMPRESSION_CLOSE capsule with the context ID set to the one from the received COMPRESSION_ASSIGN capsule
 
-The client or proxy MAY choose to close any context contexts that it registered
+The client or proxy MAY choose to close any context that it registered
 or was registered with it respectively using COMPRESSION_CLOSE
 (For example when a mapping is unused for a long time). Another potential use
 is {{restrictingips}}.

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -148,8 +148,6 @@ Listener UDP Proxying Compressed Payload {
 ~~~
 {: #dgram-format-compressed title="Compressed Bound UDP Proxying HTTP Datagram Format"}
 
-{: #dgram-format title="Bound UDP Proxying HTTP Datagram Format"}
-
 IP Version:
 
 : The IP Version of the following IP Address field. MUST be 4 or 6.

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -15,8 +15,8 @@ venue:
   type: "Working Group"
   mail: "masque@ietf.org"
   arch: "https://mailarchive.ietf.org/arch/browse/masque/"
-  github: "DavidSchinazi/draft-schinazi-connect-udp-listen"
-  latest: "https://DavidSchinazi.github.io/draft-schinazi-connect-udp-listen/draft-ietf-masque-connect-udp-listen.html"
+  github: "ietf-wg-masque/draft-ietf-masque-connect-udp-listen"
+  latest: "https://ietf-wg-masque.github.io/draft-ietf-masque-connect-udp-listen/draft-ietf-masque-connect-udp-listen.html"
 keyword:
   - quic
   - http

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -170,7 +170,7 @@ client and server must specify the IP version, IP and port of the target per
 datagram, see {{format}}. The client can compress IP and port information using
 non zero Context IDs as defined under {{compression}}.
 Receiving and forwarding from Context ID 0 is enabled by default, but may be
-disabled using {{restrictingips}}.
+disabled; see {{restrictingips}}.
 
 ## Header Compression {#compression}
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -111,6 +111,14 @@ When performing URI Template Expansion of the UDP Proxying template (see
 {{Section 3 of CONNECT-UDP}}), the client sets both the target_host and the
 target_port variables to the '*' character (ASCII character 0x2A).
 
+This extension leverages context IDs (see Section 4 of CONNECT-UDP) to compress 
+the target IP address and port when encoding datagrams on the wire. Either 
+endpoint can register a context ID and the IP/ports it's associated with by 
+sending a COMPRESSION_ASSIGN capsule to its peer. The peer will then echo that 
+capsule to indicate it's received it. From then on, both endpoints are aware of 
+the context ID and can send compressed datagrams. Later, any endpoint can 
+decide to close the compression context by sending a COMPRESSION_CLOSE capsule.
+
 Before sending its UDP Proxying request to the proxy, the client allocates an
 even-numbered context ID, see {{Section 4 of CONNECT-UDP}}. The client then adds
 the "connect-udp-bind" header field to its UDP Proxying request, with its
@@ -408,6 +416,9 @@ back to the client.
    connect-udp-bind = 2
    capsule-protocol = ?1
 
+            <--------  STREAM(44): HEADERS
+                         :status = 200
+                         capsule-protocol = ?1
 
 /* Request Context ID 2 to be used for uncompressed UDP payloads
  from/to any target */
@@ -430,10 +441,6 @@ back to the client.
    IP Address = 192.0.2.42
    UDP Port = 1234
    UDP Payload = Encapsulated UDP Payload
-
-            <--------  STREAM(44): HEADERS
-                         :status = 200
-                         capsule-protocol = ?1
 
 /* Wait for STUN server to respond to UDP packet. */
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -146,7 +146,7 @@ Uncompressed Bound UDP Proxying Payload {
 {: #dgram-format title="Uncompressed Bound UDP Proxying HTTP Datagram Format"}
 
 ~~~ ascii-art
-Bound UDP Proxying Compressed Payload {
+Compressed Bound UDP Proxying Payload {
   UDP Payload (..),
 }
 ~~~

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -330,7 +330,7 @@ with unauthorized targets. Proxies can either silently discard such datagrams or
 abort the corresponding request stream.
 
 Note that if the compression response (COMPRESSION_ASSIGN OR COMPRESSION_CLOSE)
-cannot be immediately sent due to flow or congestion control, an upper limit on how many compression responses the endpoint is willing to buffer SHOULD be set to prevent DDOS-ing. The proxy MAY
+cannot be immediately sent due to flow or congestion control, an upper limit on how many compression responses the endpoint is willing to buffer MUST be set to prevent memory exhaustion. The proxy MAY
 close the connection if such conditions occur.
 
 # IANA Considerations

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -77,9 +77,9 @@ tunnels for communicating UDP payloads {{!UDP=RFC0768}} to a fixed host and
 port. Combined with the HTTP CONNECT method (see {{Section 9.3.6 of
 !HTTP=RFC9110}}), it allows proxying the majority of a Web Browser's HTTP
 traffic. However WebRTC {{WebRTC}} relies on ICE {{?ICE=RFC8445}} to provide
-connectivity between two Web browsers, and ICE relies on the ability to send and
-receive UDP packets to multiple hosts. While in theory it might be possible to
-accomplish this using multiple UDP Proxying HTTP requests, HTTP semantics
+connectivity between two Web browsers, and ICE relies on the ability to send 
+and receive UDP packets to multiple hosts. While in theory it might be possible
+to accomplish this using multiple UDP Proxying HTTP requests, HTTP semantics
 {{HTTP}} do not guarantee that distinct requests will be handled by the same
 server. This can lead to the UDP packets being sent from distinct IP addresses,
 thereby preventing ICE from operating correctly. Consequently, UDP Proxying
@@ -94,16 +94,16 @@ Proxying HTTP request.
 {::boilerplate bcp14-tagged}
 
 This document uses terminology from {{CONNECT-UDP}} and notational conventions
-from {{!QUIC=RFC9000}}. This document uses the terms Integer, Boolean and List from
-{{Section 3 of !STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing.
+from {{!QUIC=RFC9000}}. This document uses the terms Integer, Boolean and List
+from {{Section 3 of !STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing.
 
 
 # Proxied UDP Binding Mechanism {#mechanism}
 
 In unextended UDP Proxying requests, the target host is encoded in the HTTP
-request path or query. For Bound UDP Proxying, the target is either conveyed in each
-HTTP Datagram (see {{format}}), or registered via capsules and then compressed
-(see {{contextid}}).
+request path or query. For Bound UDP Proxying, the target is either conveyed
+in each HTTP Datagram (see {{format}}), or registered via capsules and then
+compressed (see {{contextid}}).
 
 When performing URI Template Expansion of the UDP Proxying template (see
 {{Section 3 of CONNECT-UDP}}), the client sets both the target_host and the
@@ -144,7 +144,8 @@ Compressed Bound UDP Proxying Payload {
   UDP Payload (..),
 }
 ~~~
-{: #dgram-format-compressed title="Compressed Bound UDP Proxying HTTP Datagram Format"}
+{: #dgram-format-compressed title="Compressed Bound UDP Proxying HTTP 
+Datagram Format"}
 
 IP Version:
 
@@ -153,10 +154,10 @@ IP Version:
 IP Address:
 
 : The IP Address of this proxied UDP packet. When sent from client to proxy,
-this is the target host to which the proxy will send this UDP payload. When sent
-from proxy to client, this represents the source IP address of the UDP packet
-received by the proxy. This field has a length of 32 bits when the corresponding
-IP Version field value is 4, and 128 when the IP Version is 6.
+this is the target host to which the proxy will send this UDP payload. When 
+sent from proxy to client, this represents the source IP address of the UDP
+packet received by the proxy. This field has a length of 32 bits when the
+corresponding IP Version field value is 4, and 128 when the IP Version is 6.
 
 UDP Port:
 
@@ -172,18 +173,26 @@ octets" in {{UDP}}).
 
 # Context ID {#contextid}
 
-This extension leverages context IDs (see {{Section 4 of CONNECT-UDP}}) to compress the target IP address and port when encoding datagrams on the wire. Either endpoint can register a context ID and the IP/ports it's associated with by sending a COMPRESSION_ASSIGN capsule to its peer. The peer will then echo that capsule to indicate it's received it. From then on, both endpoints are aware of the context ID and can send compressed datagrams. Later, any endpoint can decide to close the compression context by sending a COMPRESSION_CLOSE capsule.
+This extension leverages context IDs (see {{Section 4 of CONNECT-UDP}}) to
+compress the target IP address and port when encoding datagrams on the wire.
+Either endpoint can register a context ID and the IP/ports it's associated
+with by sending a COMPRESSION_ASSIGN capsule to its peer. The peer will then
+echo that capsule to indicate it's received it. From then on, both endpoints
+are aware of the context ID and can send compressed datagrams. Later, any
+endpoint can decide to close the compression context by sending a
+COMPRESSION_CLOSE capsule.
 
-The context ID 0 was reserved by unextended connect-udp and is not used by this extension.
-Once an endpoint has ascertained that the peer supports this extension, the endpoint MUST NOT
-send any datagrams with context ID set to 0, and MUST silently drop any received datagrams with
-context ID set to 0.
+The context ID 0 was reserved by unextended connect-udp and is not used by
+this extension. Once an endpoint has ascertained that the peer supports this
+extension, the endpoint MUST NOT send any datagrams with context ID set to 0,
+and MUST silently drop any received datagrams with context ID set to 0.
 
-As mandated in {{Section 4 of CONNECT-UDP}}, clients will allocate even context IDs
-while proxies will allocate odd ones.
-They MAY pre-emptively use Context IDs not yet acknowledged by the other party, knowing that those packets can be lost since the COMPRESSION_ASSIGN request receiving proxy
-or client is not guaranteed to be ready to accept payloads until a COMPRESSION_ASSIGN
-response is echoed back.
+As mandated in {{Section 4 of CONNECT-UDP}}, clients will allocate even context
+IDs while proxies will allocate odd ones.
+They MAY pre-emptively use Context IDs not yet acknowledged by the other party,
+knowing that those packets can be lost since the COMPRESSION_ASSIGN request
+receiving proxy or client is not guaranteed to be ready to accept payloads
+until a COMPRESSION_ASSIGN response is echoed back.
 
 ## Address Compression {#compression}
 
@@ -197,35 +206,39 @@ if it accepts the compression request, or a COMPRESSION_CLOSE with the context
 ID (see {{capsulecloseformat}}) if it doesn't wish to support  compression for
 the given Context ID (For example, due to the memory cost of
 establishing  a list of mappings per target per client). If the compression was
-rejected, the client and proxy MUST use an uncompressed context ID (See {{uncompressed}}) to exhange
-UDP payloads for the given target.
+rejected, the client and proxy MUST use an uncompressed context ID 
+(See {{uncompressed}}) to exhange UDP payloads for the given target.
 
 ### Uncompressed datagrams {#uncompressed}
 
 If the client wishes to allocate a Context ID for uncompressed packets,
-it MUST first exchange the COMPRESSION_ASSIGN capsule (see {{capsuleassignformat}})
-with the proxy with an unused Context ID defined in {{contextid}} with
-the IP Length set to zero.
+it MUST first exchange the COMPRESSION_ASSIGN capsule 
+(see {{capsuleassignformat}}) with the proxy with an unused Context ID
+defined in {{contextid}} with the IP Length set to zero.
 
 
 ### Compression Mapping {#mappings}
 
-When an endpoint receives a COMPRESSION_ASSIGN capsule with a non-zero IP length, it MUST decide whether to accept or reject the compression mapping:
+When an endpoint receives a COMPRESSION_ASSIGN capsule with a non-zero IP
+length, it MUST decide whether to accept or reject the compression mapping:
 
-if it accepts the mapping, first the receiver MUST save the mapping from context ID to address and port. Second, the receiver MUST echo an identical COMPRESSION_ASSIGN capsule back to its peer.
+if it accepts the mapping, first the receiver MUST save the mapping from
+context ID to address and port. Second, the receiver MUST echo an identical COMPRESSION_ASSIGN capsule back to its peer.
 
-if it rejects the mapping, the receiver MUST respond by sending a COMPRESSION_CLOSE capsule with the context ID set to the one from the received COMPRESSION_ASSIGN capsule
+if it rejects the mapping, the receiver MUST respond by sending a
+COMPRESSION_CLOSE capsule with the context ID set to the one from the received COMPRESSION_ASSIGN capsule
 
 The client or proxy MAY choose to close any context contexts that it registered
 or was registered with it respectively using COMPRESSION_CLOSE
-(For example when a mapping is unused for a long time). Another potential use is
-{{restrictingips}}.
+(For example when a mapping is unused for a long time). Another potential use
+is {{restrictingips}}.
 
 
 ## Restricting IPs {#restrictingips}
 
-If an uncompressed Context ID was set (via {{uncompressed}}), the client MAY at any point request the proxy reject all traffic from uncompressed
-targets by using COMPRESSION_CLOSE (see {{compressionclose}}) on said Context ID.
+If an uncompressed Context ID was set (via {{uncompressed}}), the client MAY at
+any point request the proxy reject all traffic from uncompressed targets by 
+using COMPRESSION_CLOSE (see {{compressionclose}}) on said Context ID.
 targets effectively acting as a firewall against unwanted or unknown IPs.
 
 
@@ -235,7 +248,9 @@ The Listener capsule types are defined as follows:
 
 ### The COMPRESSION_ASSIGN capsule {#compressionassign}
 
-The Compression Assign capsule has two purposes. Either to request the assignment of a Context ID (see {{contextid}}) to a corresponding target IP:Port. Or to accept a COMPRESSION_ASSIGN request from the other party.
+The Compression Assign capsule has two purposes. Either to request the 
+assignment of a Context ID (see {{contextid}}) to a corresponding target IP:Port.
+Or to accept a COMPRESSION_ASSIGN request from the other party.
 
 ~~~ ascii-art
 Capsule {
@@ -262,7 +277,11 @@ to 0 when allocating an uncompressed Context ID, as defined in {{contextid}}.
 
 ### The COMPRESSION_CLOSE capsule {#compressionclose}
 
-The Compression Close capsule serves the following purposes. As a response to reject a COMPRESSION_ASSIGN request and to close or clean up any existing compression mappings. Once a COMPRESSION_CLOSE is sent for a given Context ID, the sending party MAY drop any datagrams received for that Context ID until it is reallocated through a COMPRESSION_ASSIGN exchange.
+The Compression Close capsule serves the following purposes. As a response to
+reject a COMPRESSION_ASSIGN request and to close or clean up any existing
+compression mappings. Once a COMPRESSION_CLOSE is sent for a given Context ID,
+the sending party MAY drop any datagrams received for that Context ID until it
+is reallocated through a COMPRESSION_ASSIGN exchange.
 
 ~~~
 Capsule {
@@ -296,27 +315,29 @@ the client if a corresponding Context ID mapping exist.
 
 If the proxy receives UDP payloads that don't correspond to any mapping i.e.
 no compression for the given target was ever established and a mapping for
-uncompressed or any target is missing, the proxy will either drop the datagram or
-temporarily buffer it (see {{Section 5 of CONNECT-UDP}}).
+uncompressed or any target is missing, the proxy will either drop the datagram
+or temporarily buffer it (see {{Section 5 of CONNECT-UDP}}).
 
 
 # Security Considerations
 
-The security considerations described in {{Section 7 of CONNECT-UDP}} also apply
-here. Since TURN can be run over this mechanism, implementors should review the
-security considerations in {{Section 21 of ?TURN=RFC8656}}.
+The security considerations described in {{Section 7 of CONNECT-UDP}} also
+apply here. Since TURN can be run over this mechanism, implementors should 
+review the security considerations in {{Section 21 of ?TURN=RFC8656}}.
 
 Since unextended UDP Proxying requests carry the target as part of the request,
-the proxy can protect unauthorized targets by rejecting requests before creating
-the tunnel, and communicate the rejection reason in response header fields.
-Bound UDP Proxying requests do not have this ability. Therefore, proxies MUST
-validate the target on every datagram and MUST NOT forward individual datagrams
-with unauthorized targets. Proxies can either silently discard such datagrams or
-abort the corresponding request stream.
+the proxy can protect unauthorized targets by rejecting requests before
+creating the tunnel, and communicate the rejection reason in response header 
+fields. Bound UDP Proxying requests do not have this ability. Therefore, 
+proxies MUST validate the target on every datagram and MUST NOT forward 
+individual datagrams with unauthorized targets. Proxies can either silently
+discard such datagrams or abort the corresponding request stream.
 
 Note that if the compression response (COMPRESSION_ASSIGN OR COMPRESSION_CLOSE)
-cannot be immediately sent due to flow or congestion control, an upper limit on how many compression responses the endpoint is willing to buffer MUST be set to prevent memory exhaustion. The proxy MAY
-close the connection if such conditions occur.
+cannot be immediately sent due to flow or congestion control, an upper limit
+on how many compression responses the endpoint is willing to buffer MUST be set
+to prevent memory exhaustion. The proxy MAY close the connection if such
+conditions occur.
 
 # IANA Considerations
 
@@ -341,7 +362,8 @@ Comments:
 {: spacing="compact"}
 
 
-This document also requests IANA to register the following new "HTTP Capsule Types" maintained at
+This document also requests IANA to register the following new 
+"HTTP Capsule Types" maintained at
 <[](https://www.iana.org/assignments/masque)>:
 
 Value:
@@ -384,10 +406,10 @@ Comments:
 In the example below, the client is configured with URI Template
 "https://example.org/.well-known/masque/udp/{target_host}/{target_port}/" and
 wishes to use WebRTC with another browser over a Bound UDP Proxying tunnel.
-It contacts a STUN server at 192.0.2.42. The STUN server, in response, sends the
-proxy's IP address to the other browser at 203.0.113.33. Using this information,
-the other browser sends a UDP packet to the proxy, which is proxied over HTTP
-back to the client.
+It contacts a STUN server at 192.0.2.42. The STUN server, in response, sends
+the proxy's IP address to the other browser at 203.0.113.33. Using this 
+information, the other browser sends a UDP packet to the proxy, which is 
+proxied over HTTP back to the client.
 
 ~~~ ascii-art
  Client                                             Server

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -128,7 +128,7 @@ Proxying request contain the context ID in the Connect-UDP-Bind header field,
 the format of their UDP Proxying Payload field (see {{Section 5 of
 CONNECT-UDP}}) is defined by {{dgram-format}} when context ID is set to the value
 used for uncompressed CONNECT UDP bind and {{dgram-format-compressed}} when
-context ID is any other value.
+context ID matches one registered for compressed payloads.
 (See {{contextid}} for compressed and uncompressed assignments.)
 
 ~~~ ascii-art

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -101,7 +101,7 @@ from {{!QUIC=RFC9000}}. This document uses the terms Integer and List from
 
 In unextended UDP Proxying requests, the target host is encoded in the HTTP
 request path or query. For Listener UDP Proxying, it is either conveyed in each
-HTTP Datagram, see {{format}} or registered via DATAGRAM capsules and then compressed, see {{contextid}}.
+HTTP Datagram, see {{format}} or registered via capsules and then compressed, see {{contextid}}.
 
 When performing URI Template Expansion of the UDP Proxying template (see
 {{Section 3 of CONNECT-UDP}}), the client sets both the target_host and the

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -330,8 +330,7 @@ with unauthorized targets. Proxies can either silently discard such datagrams or
 abort the corresponding request stream.
 
 Note that if the compression response (COMPRESSION_ASSIGN OR COMPRESSION_CLOSE)
-cannot be immediately sent due to flow or congestion control, an upper limit of
-how much it is willing to proxy SHOULD be set to prevent DDOS-ing. The proxy MAY
+cannot be immediately sent due to flow or congestion control, an upper limit on how many compression responses the endpoint is willing to buffer SHOULD be set to prevent DDOS-ing. The proxy MAY
 consider closing the connection if such conditions occur.
 
 # IANA Considerations

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -203,7 +203,7 @@ In such a case, the client or the proxy sends a COMPRESSION_ASSIGN capsule
 {{targetmappingformat}}) it wishes to compress and the other party (proxy or
 client respectively) echoes back with either a COMPRESSION_ASSIGN capsule
 if it accepts the compression request, or a COMPRESSION_CLOSE with the context
-ID (see {{capsulecloseformat}}) if it doesn't wish to support  compression for
+ID (see {{capsulecloseformat}}) if it doesn't wish to support compression for
 the given Context ID (For example, due to the memory cost of
 establishing  a list of mappings per target per client). If the compression was
 rejected, the client and proxy MUST use an uncompressed context ID
@@ -280,8 +280,7 @@ to 0 when allocating an uncompressed Context ID, as defined in {{contextid}}.
 The Compression Close capsule serves the following purposes. As a response to
 reject a COMPRESSION_ASSIGN request and to close or clean up any existing
 compression mappings. Once a COMPRESSION_CLOSE has been exchanged between
-endpoints, they MUST NOT use that Context ID until it is re-assigned via a
-COMPRESSION_ASSIGN exchange.
+endpoints, they MUST NOT use that Context ID again.
 
 ~~~
 Capsule {

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -180,14 +180,14 @@ Once an endpoint has ascertained that the peer supports this extension, the endp
 send any datagrams with context ID set to 0, and MUST drop any received datagrams with
 context ID set to 0.
 
-An even context ID MUST be used by clients to send packets to the proxy, and an odd
-context ID MUST be used by the proxy to send packets to the client. A Client and
-a proxy MUST exhange COMPRESSION_ASSIGN packets for a given context ID to guarantee
-that all payloads are received and processed by the other party, see
-{{compression}}. They MAY pre-emptively use Context IDs not acknowledged by the
-other party yet, knowing that those packets MAY be lost since the client is not
-guaranteed to be ready to receive until it receives the acknowledgement
-COMPRESSION_ASSIGN.
+An even context ID MUST be used by clients to allocate uncompressed or compressed
+contexts, and an odd context ID MUST be used by the proxy to allocate compressed
+context IDs. A Client and a proxy MUST exhange COMPRESSION_ASSIGN packets for a 
+given context ID to guarantee that all payloads are received and processed by the
+other party, see {{compression}}. They MAY pre-emptively use Context IDs not 
+acknowledged by the other party yet, knowing that those packets MAY be lost sinc
+the COMPRESSION_ASSIGN request receiving proxy or client is not guaranteed to be
+ready to accept payloads until a COMPRESSION_ASSIGN response is echoed back.
 
 ## Address Compression {#compression}
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -191,7 +191,7 @@ on behalf of the client.
 Similarly, if the server sends a payload with the IP Version, IP Address
 ,and UDP Port fields, the client MUST update its mapping of the context ID to the
 provided IP Address and UDP Port. If the proxy, sends a datagram without the IP
-Version, IP Address and UDP Port fields, the client must use the mapping to 
+Version, IP Address and UDP Port fields, the client must use the mapping to
 identify which target it is receiving from.
 
 # Security Considerations
@@ -288,15 +288,15 @@ back to the client.
                          IP Address = 203.0.113.33
                          UDP Port = 4321
                          UDP Payload = Encapsulated UDP Payload
-                         
-/* Omit IP and Port info from future payloads from */ 
+
+/* Omit IP and Port info from future payloads from */
 /* 203.0.113.33:4321 until, another target sends a packet */
             <--------  DATAGRAM
                          Quarter Stream ID = 11
                          Context ID = 2
                          UDP Payload = Encapsulated UDP Payload
 
-/* Mention IP and port in the first packet intended for */ 
+/* Mention IP and port in the first packet intended for */
 /* 203.0.113.33:1234 */
  DATAGRAM                       -------->
    Quarter Stream ID = 11

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -296,14 +296,18 @@ Capsule {
 
 # The Connect-UDP-Bind Header Field {#hdr}
 
-The "Connect-UDP-Bind" header field’s value is a boolean structured field
-set to to true. Any other value type MUST be handled as if the field were not
+The "Connect-UDP-Bind" header field’s value is a Boolean Structured Field
+set to to true. When this value is set in the request, and the request is
+accepted by the proxy, the Connect-UDP-Bind extension has been enabled,
+and the proxy MUST follow {{behavior}} to deal with UDP Payloads from and
+to the client.
+Any other value type MUST be handled as if the field were not
 present by the recipients (for example, if this field is defined multiple times,
 its type becomes a List and therefore is to be ignored). This document does not
 define any parameters for the Connect-UDP-Bind header field value, but future
 documents might define parameters. Receivers MUST ignore unknown parameters.
 
-# Proxy behavior
+# Proxy behavior {#behavior}
 
 After accepting the Connect-UDP Binding proxying request, the proxy uses a UDP
 port to transmit UDP payloads received from the client to the target IP Address

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -77,7 +77,7 @@ tunnels for communicating UDP payloads {{!UDP=RFC0768}} to a fixed host and
 port. Combined with the HTTP CONNECT method (see {{Section 9.3.6 of
 !HTTP=RFC9110}}), it allows proxying the majority of a Web Browser's HTTP
 traffic. However WebRTC {{WebRTC}} relies on ICE {{?ICE=RFC8445}} to provide
-connectivity between two Web browsers, and ICE relies on the ability to send 
+connectivity between two Web browsers, and ICE relies on the ability to send
 and receive UDP packets to multiple hosts. While in theory it might be possible
 to accomplish this using multiple UDP Proxying HTTP requests, HTTP semantics
 {{HTTP}} do not guarantee that distinct requests will be handled by the same
@@ -144,7 +144,7 @@ Compressed Bound UDP Proxying Payload {
   UDP Payload (..),
 }
 ~~~
-{: #dgram-format-compressed title="Compressed Bound UDP Proxying HTTP 
+{: #dgram-format-compressed title="Compressed Bound UDP Proxying HTTP
 Datagram Format"}
 
 IP Version:
@@ -154,7 +154,7 @@ IP Version:
 IP Address:
 
 : The IP Address of this proxied UDP packet. When sent from client to proxy,
-this is the target host to which the proxy will send this UDP payload. When 
+this is the target host to which the proxy will send this UDP payload. When
 sent from proxy to client, this represents the source IP address of the UDP
 packet received by the proxy. This field has a length of 32 bits when the
 corresponding IP Version field value is 4, and 128 when the IP Version is 6.
@@ -206,13 +206,13 @@ if it accepts the compression request, or a COMPRESSION_CLOSE with the context
 ID (see {{capsulecloseformat}}) if it doesn't wish to support  compression for
 the given Context ID (For example, due to the memory cost of
 establishing  a list of mappings per target per client). If the compression was
-rejected, the client and proxy MUST use an uncompressed context ID 
+rejected, the client and proxy MUST use an uncompressed context ID
 (See {{uncompressed}}) to exhange UDP payloads for the given target.
 
 ### Uncompressed datagrams {#uncompressed}
 
 If the client wishes to allocate a Context ID for uncompressed packets,
-it MUST first exchange the COMPRESSION_ASSIGN capsule 
+it MUST first exchange the COMPRESSION_ASSIGN capsule
 (see {{capsuleassignformat}}) with the proxy with an unused Context ID
 defined in {{contextid}} with the IP Length set to zero.
 
@@ -237,7 +237,7 @@ is {{restrictingips}}.
 ## Restricting IPs {#restrictingips}
 
 If an uncompressed Context ID was set (via {{uncompressed}}), the client MAY at
-any point request the proxy reject all traffic from uncompressed targets by 
+any point request the proxy reject all traffic from uncompressed targets by
 using COMPRESSION_CLOSE (see {{compressionclose}}) on said Context ID.
 targets effectively acting as a firewall against unwanted or unknown IPs.
 
@@ -248,7 +248,7 @@ The Listener capsule types are defined as follows:
 
 ### The COMPRESSION_ASSIGN capsule {#compressionassign}
 
-The Compression Assign capsule has two purposes. Either to request the 
+The Compression Assign capsule has two purposes. Either to request the
 assignment of a Context ID (see {{contextid}}) to a corresponding target IP:Port.
 Or to accept a COMPRESSION_ASSIGN request from the other party.
 
@@ -322,14 +322,14 @@ or temporarily buffer it (see {{Section 5 of CONNECT-UDP}}).
 # Security Considerations
 
 The security considerations described in {{Section 7 of CONNECT-UDP}} also
-apply here. Since TURN can be run over this mechanism, implementors should 
+apply here. Since TURN can be run over this mechanism, implementors should
 review the security considerations in {{Section 21 of ?TURN=RFC8656}}.
 
 Since unextended UDP Proxying requests carry the target as part of the request,
 the proxy can protect unauthorized targets by rejecting requests before
-creating the tunnel, and communicate the rejection reason in response header 
-fields. Bound UDP Proxying requests do not have this ability. Therefore, 
-proxies MUST validate the target on every datagram and MUST NOT forward 
+creating the tunnel, and communicate the rejection reason in response header
+fields. Bound UDP Proxying requests do not have this ability. Therefore,
+proxies MUST validate the target on every datagram and MUST NOT forward
 individual datagrams with unauthorized targets. Proxies can either silently
 discard such datagrams or abort the corresponding request stream.
 
@@ -362,7 +362,7 @@ Comments:
 {: spacing="compact"}
 
 
-This document also requests IANA to register the following new 
+This document also requests IANA to register the following new
 "HTTP Capsule Types" maintained at
 <[](https://www.iana.org/assignments/masque)>:
 
@@ -407,8 +407,8 @@ In the example below, the client is configured with URI Template
 "https://example.org/.well-known/masque/udp/{target_host}/{target_port}/" and
 wishes to use WebRTC with another browser over a Bound UDP Proxying tunnel.
 It contacts a STUN server at 192.0.2.42. The STUN server, in response, sends
-the proxy's IP address to the other browser at 203.0.113.33. Using this 
-information, the other browser sends a UDP packet to the proxy, which is 
+the proxy's IP address to the other browser at 203.0.113.33. Using this
+information, the other browser sends a UDP packet to the proxy, which is
 proxied over HTTP back to the client.
 
 ~~~ ascii-art

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -282,12 +282,12 @@ Capsule {
 
 # The connect-udp-bind Header Field {#hdr}
 
-The "connect-udp-bind" header field’s value is a boolean set to true. Any other
-value type MUST be handled as if the field were not present by the recipients
-(for example, if this field is defined multiple times, its type becomes a List
-and therefore is to be ignored). This document does not define any parameters
-for the Connect-UDP-Bind header field value, but future documents might define
-parameters. Receivers MUST ignore unknown parameters.
+The "connect-udp-bind" header field’s value is a boolean structured value field
+set to to true. Any other value type MUST be handled as if the field were not
+present by the recipients (for example, if this field is defined multiple times,
+its type becomes a List and therefore is to be ignored). This document does not
+define any parameters for the Connect-UDP-Bind header field value, but future
+documents might define parameters. Receivers MUST ignore unknown parameters.
 
 # Proxy behavior
 
@@ -413,7 +413,7 @@ back to the client.
    :scheme = https
    :path = /.well-known/masque/udp/*/*/
    :authority = proxy.example.org
-   connect-udp-bind = 1
+   connect-udp-bind = ?1
    capsule-protocol = ?1
 
             <--------  STREAM(44): HEADERS

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -117,7 +117,7 @@ the "connect-udp-bind" header field to its UDP Proxying request, with its
 value set as the allocated context ID, see {{contextid}}. Likewise, the proxy
 can allocate and use odd numbered context IDs to send payloads to the client.
 
-The client and the proxy MUST exchange COMPRESSION_ASSIGN capsules in order to
+The client and the proxy exchange COMPRESSION_ASSIGN capsules in order to
 establish which IP a given context ID corresponds to. The context ID can
 correspond to uncompressed payloads to/from any target i.e. any value.
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -117,7 +117,7 @@ value set as the allocated context ID, see {{hdr}}.
 When HTTP Datagrams {{!HTTP-DGRAM=RFC9297}} associated with this Listener UDP
 Proxying request contain the context ID in the connect-udp-listen header field,
 the format of their UDP Proxying Payload field (see {{Section 5 of
-CONNECT-UDP}}) is defined by {{dgram-format}}:
+CONNECT-UDP}}), is defined by {{dgram-format}}
 
 ~~~ ascii-art
 Listener UDP Proxying Payload {
@@ -131,7 +131,10 @@ Listener UDP Proxying Payload {
 
 IP Version:
 
-: The IP Version of the following IP Address field. MUST be 4 or 6.
+: The IP Version of the following IP Address field. MUST be 4 or 6. 
+MAY be omitted if the latest previously transmitted Target IP Address and Port
+for the Context ID are the same as the current target IP Address and Port.
+If Omitted, the IP Address and UDP Port fields MUST also be omitted.
 
 IP Address:
 
@@ -140,13 +143,19 @@ this is the target host to which the proxy will send this UDP payload. When sent
 from proxy to client, this represents the source IP address of the UDP packet
 received by the proxy. This field has a length of 32 bits when the corresponding
 IP Version field value is 4, and 128 when the IP Version is 6.
+MAY be omitted if the latest previously transmitted Target IP Address and
+Port for the Context ID are the same as the current target IP Address and Port.
+If Omitted, the UDP Port and IP Version fields MUST also be omitted.
 
 UDP Port:
 
 : The UDP Port of this proxied UDP packet in network byte order. When sent from
 client to proxy, this is the target port to which the proxy will send this UDP
 payload. When sent from proxy to client, this represents the source UDP port of
-the UDP packet received by the proxy.
+the UDP packet received by the proxy. MAY be omitted if the latest previously
+transmitted Target IP Address and Port for the Context ID are the same as the 
+current target IP Address and Port. If Omitted, the IP Address and IP Version
+fields MUST also be omitted.
 
 UDP Payload:
 
@@ -172,7 +181,13 @@ and UDP Port specified in each Listener Datagram Payload received from the
 client. The proxy uses the same port to listen for UDP packets from any
 authorized target and encapsulates the packets in the Listener Datagram
 Payload format, specifying the IP and port of the target and forwards it to
-the client.
+the client. The proxy MUST keep a mapping of Context-IDs to IP Addresses and UDP
+Ports. If the client sends a payload defined in {#format} with the IP Version,
+IP Address and UDP Port fields, the proxy MUST update its mapping of the context
+ID to the provided IP Address and UDP Port. If the client sends a UDP datagram 
+without the IP Version, IP Address and UDP Port fields, the proxy MUST use the
+mapping to identify the target in order to transmit UDP Payloads
+on behalf of the client.
 
 # Security Considerations
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -298,8 +298,8 @@ client. The proxy uses the same port to listen for UDP packets from any
 authorized target and encapsulates the packets in the Binding Datagram
 Payload format, specifying the IP and port of the target and forwards it to
 the client.
-When the client or proxy send a COMPRESSION_ASSIGN capsule, the proxy or client
-respectively either register a mapping from Context ID to the provided target
+When an endpoint receives a COMPRESSION_ASSIGN capsule, it
+either registers a mapping from Context ID to the provided target
 and port and echo back the capsule or reject. If the IP length was 0,
 the Context ID can be used by either party to send uncompressed payloads and
 the proxy reads the IP, port information per  packet, as opposed to doing a

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -312,7 +312,8 @@ uncompressed.
 
 If the proxy receives UDP payloads that don't correspond to any mapping i.e.
 no compression for the given target was ever established and a mapping for
-uncompressed or any target is missing, the proxy simply drops the packet.
+uncompressed or any target is missing, the proxy will either drop the datagram or
+temporarily buffer it (see {{Section 5 of CONNECT-UDP}}).
 
 
 # Security Considerations

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -182,9 +182,9 @@ context ID set to 0.
 
 An even context ID MUST be used by clients to allocate uncompressed or compressed
 contexts, and an odd context ID MUST be used by the proxy to allocate compressed
-context IDs. A Client and a proxy MUST exhange COMPRESSION_ASSIGN packets for a 
+context IDs. A Client and a proxy MUST exhange COMPRESSION_ASSIGN packets for a
 given context ID to guarantee that all payloads are received and processed by the
-other party, see {{compression}}. They MAY pre-emptively use Context IDs not 
+other party, see {{compression}}. They MAY pre-emptively use Context IDs not
 acknowledged by the other party yet, knowing that those packets MAY be lost sinc
 the COMPRESSION_ASSIGN request receiving proxy or client is not guaranteed to be
 ready to accept payloads until a COMPRESSION_ASSIGN response is echoed back.

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -199,15 +199,15 @@ until a COMPRESSION_ASSIGN response is echoed back.
 The client and the proxy MAY choose to compress the IP and port information
 per datagram for a given target against the Context ID.
 In such a case, the client or the proxy sends a COMPRESSION_ASSIGN capsule
-(see {{capsuleassignformat}}) with the target information (see
-{{targetmappingformat}}) it wishes to compress and the other party (proxy or
-client respectively) echoes back with either a COMPRESSION_ASSIGN capsule
-if it accepts the compression request, or a COMPRESSION_CLOSE with the context
-ID (see {{capsulecloseformat}}) if it doesn't wish to support compression for
-the given Context ID (For example, due to the memory cost of
-establishing  a list of mappings per target per client). If the compression was
-rejected, the client and proxy MUST use an uncompressed context ID
-(See {{uncompressed}}) to exhange UDP payloads for the given target.
+(see {{capsuleassignformat}}) with the target information it wishes to
+compress and the other party (proxy or client respectively) echoes back
+with either a COMPRESSION_ASSIGN capsule if it accepts the compression request,
+or a COMPRESSION_CLOSE with the context ID (see {{capsulecloseformat}}) if it
+doesn't wish to support compression for the given Context ID (For example,
+due to the memory cost of establishing  a list of mappings per target per
+client). If the compression was rejected, the client and proxy MUST use an
+uncompressed context ID (See {{uncompressed}}) to exhange UDP payloads for
+the given target.
 
 ### Uncompressed datagrams {#uncompressed}
 
@@ -215,7 +215,6 @@ If the client wishes to allocate a Context ID for uncompressed packets,
 it MUST first exchange the COMPRESSION_ASSIGN capsule
 (see {{capsuleassignformat}}) with the proxy with an unused Context ID
 defined in {{contextid}} with the IP Length set to zero.
-
 
 ### Compression Mapping {#mappings}
 
@@ -256,22 +255,15 @@ Or to accept a COMPRESSION_ASSIGN request from the other party.
 Capsule {
   Type COMPRESSION_ASSIGN (0x1C0FE323),
   Length (i),
-  Target Information,
+  Context ID (i),
+  IP Version (8),
+  IP Address (32..128),
+  UDP Port (16),
 }
 ~~~
 {: #capsuleassignformat title="Compression Assign Capsule Format"}
 
-~~~
-Target Information {
-  Context ID (i),
-  IP Version (8),
-  [IP Address (32..128)],
-  [UDP Port (16)],
-}
-~~~
-{: #targetmappingformat title="Target Information Format"}
-
-The IP Length, Address and Port fields in {{targetmappingformat}} are the
+The IP Length, Address and Port fields in {{capsuleassignformat}} are the
 same as those defined in {{format}}. However, the IP version can be set
 to 0 when allocating an uncompressed Context ID, as defined in {{contextid}}.
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -201,7 +201,7 @@ In such a case, the client or the proxy MUST send a COMPRESSION_ASSIGN capsule
 client respectively) MUST echo back with either a  COMPRESSION_ASSIGN capsule
 if it accepts the compression request, or a  COMPRESSION_CLOSE with the context
 ID (see {{capsulecloseformat}}) if it doesn't wish to support  compression for
-the given Context ID (For example, due to \considerable memory requirements of
+the given Context ID (For example, due to considerable memory requirements of
 establishing  a list of mappings per target per client). If the compression was
 rejected, the client and proxy MUST use an uncompressed context ID to exhange
 UDP payloads for the given target.

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -110,7 +110,9 @@ When performing URI Template Expansion of the UDP Proxying template (see
 target_port variables to the '*' character (ASCII character 0x2A).
 
 When sending the UDP Proxying request to the proxy, the client adds
-the "Connect-UDP-Bind" header field to identify it as such. Both client and proxy can negotiate even and odd numbered context IDs to send UDP payloads to each other.
+the "Connect-UDP-Bind" header field to identify it as such. Both client and
+proxy can negotiate even and odd numbered context IDs to send UDP
+payloads to each other.
 
 The client and the proxy exchange COMPRESSION_ASSIGN capsules in order to
 establish which IP a given context ID corresponds to. The context ID can

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -131,7 +131,7 @@ When HTTP Datagrams {{!HTTP-DGRAM=RFC9297}} associated with this Bound UDP
 Proxying request contain the Connect-UDP-Bind header field,
 the format of their UDP Proxying Payload field (see {{Section 5 of
 CONNECT-UDP}}) is defined by {{dgram-format}} when context ID is set to be used
-used for uncompressed CONNECT UDP bind and {{dgram-format-compressed}} when
+used for uncompressed connect-udp bind and {{dgram-format-compressed}} when
 context ID is set to one previously registered for compressed payloads.
 (See {{contextid}} for compressed and uncompressed assignments.)
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -245,7 +245,7 @@ Capsule {
 ~~~
 {: #capsuleassignformat title="Compression Assign Capsule Format"}
 
-~~~ ascii-art
+~~~
 Target Information {
   Context ID (i),
   IP Version (8),

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -94,7 +94,7 @@ Proxying HTTP request.
 {::boilerplate bcp14-tagged}
 
 This document uses terminology from {{CONNECT-UDP}} and notational conventions
-from {{!QUIC=RFC9000}}. This document uses the terms Integer and List from
+from {{!QUIC=RFC9000}}. This document uses the terms Integer, Boolean and List from
 {{Section 3 of !STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing.
 
 
@@ -282,7 +282,7 @@ Capsule {
 
 # The connect-udp-bind Header Field {#hdr}
 
-The "connect-udp-bind" header field’s value is a boolean structured value field
+The "connect-udp-bind" header field’s value is a boolean structured field
 set to to true. Any other value type MUST be handled as if the field were not
 present by the recipients (for example, if this field is defined multiple times,
 its type becomes a List and therefore is to be ignored). This document does not

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -279,9 +279,9 @@ to 0 when allocating an uncompressed Context ID, as defined in {{contextid}}.
 
 The Compression Close capsule serves the following purposes. As a response to
 reject a COMPRESSION_ASSIGN request and to close or clean up any existing
-compression mappings. Once a COMPRESSION_CLOSE is sent for a given Context ID,
-the sending party MAY drop any datagrams received for that Context ID until it
-is reallocated through a COMPRESSION_ASSIGN exchange.
+compression mappings. Once a COMPRESSION_CLOSE has been exchanged between
+endpoints, they MUST NOT use that Context ID until it is re-assigned via a 
+COMPRESSION_ASSIGN exchange.
 
 ~~~
 Capsule {

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -230,6 +230,7 @@ targets effectively acting as a firewall against unwanted or unknown IPs.
 
 
 ## Capsules {#capsules}
+
 The Listener capsule types are defined as follows:
 
 ### The COMPRESSION_ASSIGN capsule {#compressionassign}

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -331,7 +331,7 @@ abort the corresponding request stream.
 
 Note that if the compression response (COMPRESSION_ASSIGN OR COMPRESSION_CLOSE)
 cannot be immediately sent due to flow or congestion control, an upper limit on how many compression responses the endpoint is willing to buffer SHOULD be set to prevent DDOS-ing. The proxy MAY
-consider closing the connection if such conditions occur.
+close the connection if such conditions occur.
 
 # IANA Considerations
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -182,7 +182,7 @@ context ID set to 0.
 
 An even context ID MUST be used by clients to allocate uncompressed or compressed
 contexts, and an odd context ID MUST be used by the proxy to allocate compressed
-context IDs. A Client and a proxy MUST exhange a COMPRESSION_ASSIGN request and echo
+context IDs. A Client and a proxy exhange a COMPRESSION_ASSIGN request and echo
 response in order to successfully allocate a new context ID and guarantee that all
 payloads are received and processed by the other party, see {{compression}}. They
 MAY pre-emptively use Context IDs not yet acknowledged by the other party, knowing

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -261,7 +261,7 @@ to 0 when allocating an uncompressed Context ID, as defined in {{contextid}}.
 
 ### The COMPRESSION_CLOSE capsule {#compressionclose}
 
-The Compression Close capsule serves the following purposes. As a response to reject a COMPRESSION_ASSIGN request and to close or clean up any existing compression mappings. Once a COMPRESSION_CLOSE is sent for a given Context ID, the sending party MAY reject any datagrams received for that Context ID until it is reallocated through a COMPRESSION_ASSIGN exchange.
+The Compression Close capsule serves the following purposes. As a response to reject a COMPRESSION_ASSIGN request and to close or clean up any existing compression mappings. Once a COMPRESSION_CLOSE is sent for a given Context ID, the sending party MAY drop any datagrams received for that Context ID until it is reallocated through a COMPRESSION_ASSIGN exchange.
 
 ~~~ ascii-art
 Capsule {

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -119,7 +119,8 @@ can allocate and use odd numbered context IDs to send payloads to the client.
 
 The client and the proxy exchange COMPRESSION_ASSIGN capsules in order to
 establish which IP a given context ID corresponds to. The context ID can
-correspond to uncompressed payloads to/from any target i.e. any value.
+correspond to both compressed and uncompressed payloads to/from any target and
+are configured as defined in {{compression}}.
 
 # HTTP Datagram Payload Format {#format}
 

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -252,7 +252,7 @@ The Compression Assign capsule has two purposes. Either to request the
 assignment of a Context ID (see {{contextid}}) to a corresponding target IP:Port.
 Or to accept a COMPRESSION_ASSIGN request from the other party.
 
-~~~ ascii-art
+~~~
 Capsule {
   Type COMPRESSION_ASSIGN (0x1C0FE323),
   Length (i),

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -195,7 +195,7 @@ In such a case, the client or the proxy sends a COMPRESSION_ASSIGN capsule
 client respectively) echoes back with either a COMPRESSION_ASSIGN capsule
 if it accepts the compression request, or a COMPRESSION_CLOSE with the context
 ID (see {{capsulecloseformat}}) if it doesn't wish to support  compression for
-the given Context ID (For example, due to considerable memory requirements of
+the given Context ID (For example, due to the memory cost of
 establishing  a list of mappings per target per client). If the compression was
 rejected, the client and proxy MUST use an uncompressed context ID (See {{uncompressed}}) to exhange
 UDP payloads for the given target.

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -131,7 +131,7 @@ Listener UDP Proxying Payload {
 
 IP Version:
 
-: The IP Version of the following IP Address field. MUST be 4 or 6. 
+: The IP Version of the following IP Address field. MUST be 4 or 6.
 MAY be omitted if the latest previously transmitted Target IP Address and Port
 for the Context ID are the same as the current target IP Address and Port.
 If Omitted, the IP Address and UDP Port fields MUST also be omitted.
@@ -153,7 +153,7 @@ UDP Port:
 client to proxy, this is the target port to which the proxy will send this UDP
 payload. When sent from proxy to client, this represents the source UDP port of
 the UDP packet received by the proxy. MAY be omitted if the latest previously
-transmitted Target IP Address and Port for the Context ID are the same as the 
+transmitted Target IP Address and Port for the Context ID are the same as the
 current target IP Address and Port. If Omitted, the IP Address and IP Version
 fields MUST also be omitted.
 
@@ -184,10 +184,15 @@ Payload format, specifying the IP and port of the target and forwards it to
 the client. The proxy MUST keep a mapping of Context-IDs to IP Addresses and UDP
 Ports. If the client sends a payload defined in {#format} with the IP Version,
 IP Address and UDP Port fields, the proxy MUST update its mapping of the context
-ID to the provided IP Address and UDP Port. If the client sends a UDP datagram 
+ID to the provided IP Address and UDP Port. If the client sends a datagram
 without the IP Version, IP Address and UDP Port fields, the proxy MUST use the
 mapping to identify the target in order to transmit UDP Payloads
 on behalf of the client.
+Similarly, if the server sends a payload with the IP Version, IP Address
+,and UDP Port fields, the client MUST update its mapping of the context ID to the
+provided IP Address and UDP Port. If the proxy, sends a datagram without the IP
+Version, IP Address and UDP Port fields, the client must use the mapping to 
+identify which target it is receiving from.
 
 # Security Considerations
 
@@ -283,6 +288,45 @@ back to the client.
                          IP Address = 203.0.113.33
                          UDP Port = 4321
                          UDP Payload = Encapsulated UDP Payload
+                         
+/* Omit IP and Port info from future payloads from */ 
+/* 203.0.113.33:4321 until, another target sends a packet */
+            <--------  DATAGRAM
+                         Quarter Stream ID = 11
+                         Context ID = 2
+                         UDP Payload = Encapsulated UDP Payload
+
+/* Mention IP and port in the first packet intended for */ 
+/* 203.0.113.33:1234 */
+ DATAGRAM                       -------->
+   Quarter Stream ID = 11
+   Context ID = 2
+   IP Version = 4
+   IP Address = 203.0.113.33
+   UDP Port = 1234
+   UDP Payload = Encapsulated UDP Payload
+
+/* Omit IP and Port for future packets intended for*/
+/*203.0.113.33:1234 hereon */
+ DATAGRAM                       -------->
+   Quarter Stream ID = 11
+   Context ID = 2
+   UDP Payload = Encapsulated UDP Payload
+
+/* Re-add IP and Port in the first packet intended for 192.0.2.42:1234*/
+  DATAGRAM                       -------->
+   Quarter Stream ID = 11
+   Context ID = 2
+   IP Version = 4
+   IP Address = 192.0.2.42
+   UDP Port = 1234
+   UDP Payload = Encapsulated UDP Payload
+/* Remove IP and Port for packets intended for 192.0.2.42:1234 hereon */
+ DATAGRAM                       -------->
+   Quarter Stream ID = 11
+   Context ID = 2
+   UDP Payload = Encapsulated UDP Payload
+
 ~~~
 
 # Comparison with CONNECT-IP


### PR DESCRIPTION
Closes #13
Closes #14

~~clients and proxies may omit IP, Port info, if sending data to the same IP and Port as before~~

Add compression via context IDs, which are to be registered via capsules

Edit:
Also, add the ability to suppress any uncompressed traffic