### PR TITLE
Percent encode the asterisk

### DIFF
--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -108,7 +108,9 @@ compressed (see {{comp-format}}).
 
 When performing URI Template Expansion of the UDP Proxying template (see
 {{Section 3 of CONNECT-UDP}}), the client sets both the target_host and the
-target_port variables to the '*' character (ASCII character 0x2A).
+target_port variables to the '*' character (ASCII character 0x2A). Note that
+the '*' character MUST be percent-encoded before sending, per {{Section 3.2.2
+of !TEMPLATE=RFC6570}}.
 
 When sending the UDP Proxying request to the proxy, the client adds the
 "Connect-UDP-Bind" header field to identify it as such. If the proxy accepts
@@ -476,7 +478,7 @@ listen for connections from new targets, and limits its communication with only
    :method = CONNECT
    :protocol = connect-udp
    :scheme = https
-   :path = /.well-known/masque/udp/*/*/
+   :path = /.well-known/masque/udp/%2A/%2A/
    :authority = proxy.example.org
    connect-udp-bind = ?1
    capsule-protocol = ?1


### PR DESCRIPTION
Asterisks need to be percent-encoded. Let's do that (instead of picking a different character) to match connect-ip.

Fixes #30