### PR TITLE
Require that proxy cannot request compression assigns for un-observed tuples

### DIFF
--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -193,7 +193,9 @@ Endpoints MUST NOT send two COMPRESSION_ASSIGN capsules with the same Context
 ID. If a recipient detects a repeated Context ID, it MUST treat the capsule as
 malformed. Receipt of a malformed capsule MUST be treated as an error
 processing the Capsule Protocol, as defined in {{Section 3.3 of
-!HTTP-DGRAM=RFC9297}}.
+!HTTP-DGRAM=RFC9297}}. The proxy MUST NOT request compression for IP-port
+tuples that haven't previously been observed on a previously opened uncompressed
+context.
 
 Only one Context ID can be used per IP-port tuple. If an endpoint detects that
 both it and its peer have opened a Context ID for the same tuple, the endpoint

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -198,7 +198,8 @@ processing the Capsule Protocol, as defined in {{Section 3.3 of
 If the uncompressed context is closed, the proxy MUST NOT open new compressed
 contexts. In such a case, the proxy opening contexts results in tuples not
 desired by the client reaching it thereby nullifying the IP restriction
-property of compression as described in {{restricting-ips}}.
+property of uncompressed compression close as described in
+{{restricting-ips}}.
 
 Only one Context ID can be used per IP-port tuple. If an endpoint detects that
 both it and its peer have opened a Context ID for the same tuple, the endpoint

--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -193,9 +193,12 @@ Endpoints MUST NOT send two COMPRESSION_ASSIGN capsules with the same Context
 ID. If a recipient detects a repeated Context ID, it MUST treat the capsule as
 malformed. Receipt of a malformed capsule MUST be treated as an error
 processing the Capsule Protocol, as defined in {{Section 3.3 of
-!HTTP-DGRAM=RFC9297}}. The proxy MUST NOT request compression for IP-port
-tuples that haven't previously been observed on a previously opened uncompressed
-context.
+!HTTP-DGRAM=RFC9297}}.
+
+If the uncompressed context is closed, the proxy MUST NOT open new compressed
+contexts. In such a case, the proxy opening contexts results in tuples not
+desired by the client reaching it thereby nullifying the IP restriction
+property of compression as described in {{restricting-ips}}.
 
 Only one Context ID can be used per IP-port tuple. If an endpoint detects that
 both it and its peer have opened a Context ID for the same tuple, the endpoint


### PR DESCRIPTION
Fixes #34